### PR TITLE
FIX : 의견/답변 추가시 좋아요 싫어요 개수는 서버에서 정하도록 수정

### DIFF
--- a/WEB(BE)/controller/ctrl.speciality.js
+++ b/WEB(BE)/controller/ctrl.speciality.js
@@ -215,7 +215,10 @@ const speciality_opinion = async (req, res) => {
         else {
             const doc_list = snapshot.docs.map(doc => doc.id);
             const opinion_doc = doc_list[0];
-            const docRef = await addDoc(collection(db, `speciality_opinion/${opinion_doc.toString()}/opinions`), req.body);
+            const body = req.body;
+            body.like = 0;
+            body.dislike = 0;
+            const docRef = await addDoc(collection(db, `speciality_opinion/${opinion_doc.toString()}/opinions`), body);
             result.success = true;
         }
    

--- a/WEB(BE)/controller/ctrl.speciality.qna.js
+++ b/WEB(BE)/controller/ctrl.speciality.qna.js
@@ -114,7 +114,8 @@ const speciality_question = async (req, res) => {
         else {
             const doc_list = snapshot.docs.map(doc => doc.id);
             const questions_doc = doc_list[0];
-            const docRef = await addDoc(collection(db, `speciality_qna/${questions_doc}/questions`), req.body);
+            const body = req.body;
+            const docRef = await addDoc(collection(db, `speciality_qna/${questions_doc}/questions`), body);
             result.success = true;
         }
     } catch (error) {
@@ -148,7 +149,10 @@ const speciality_answer = async (req, res) => {
         else {
             const doc_list = snapshot.docs.map(doc => doc.id);
             const questions_doc = doc_list[0];
-            const docRef = await addDoc(collection(db, `speciality_qna/${questions_doc}/questions/${question_code}/answers`), req.body);
+            const body = req.body;
+            body.like = 0;
+            body.dislike = 0;
+            const docRef = await addDoc(collection(db, `speciality_qna/${questions_doc}/questions/${question_code}/answers`), body);
             result.success = true;
             
         }


### PR DESCRIPTION
지금까지는 의견/답변 추가 요청 객체에 좋아요 싫어요 개수를 담아서 요청하도록
하였으나, 좋아요 싫어요 개수는 생성됐을 때 기본적으로 0개로 설정되어야 하므로
이를 서버에서 설정하도록 수정하였습니다.