### PR TITLE
FEAT : 마이페이지 추가 및 로그인 시 아이디토큰 저장

### DIFF
--- a/WEB(FE)/mogoon/src/App.js
+++ b/WEB(FE)/mogoon/src/App.js
@@ -12,6 +12,7 @@ import SpDetail from './components/Specialty/SpDetail';
 import Login from './components/Account/Login';
 import Join from './components/Account/Join';
 import Enlist from './components/Enlist/Enlist';
+import MyPage from './components/MyPage/MyPage';
 
 //css
 import './App.css';
@@ -43,6 +44,7 @@ function App() {
             <Route path="/Specialty" element={<Specialty />}></Route>
             <Route path="/Specialty/list/:SpName/:Spkind" element={<SpDetail />}></Route>
             <Route path="/Enlist" element={<Enlist />}></Route>
+            <Route path="/MyPage" element={<MyPage />}></Route>
           </Routes>
         </div>
       </BrowserRouter>

--- a/WEB(FE)/mogoon/src/components/Account/Login.js
+++ b/WEB(FE)/mogoon/src/components/Account/Login.js
@@ -74,6 +74,7 @@ const Login = () => {
                 //data가 유일키
                 dispatch(loginUser(values));
                 localStorage.setItem("userInfo",JSON.stringify(values));
+                localStorage.setItem("IdToken",response.data.data);
                 alert("로그인 성공!");
                 reSet();
 

--- a/WEB(FE)/mogoon/src/components/Header/Header.js
+++ b/WEB(FE)/mogoon/src/components/Header/Header.js
@@ -24,6 +24,7 @@ let Header = (props) => {
         if (alertLogout) {
             dispatch(clearUser());
             localStorage.removeItem("userInfo");
+            localStorage.removeItem("IdToken");
             window.location.reload();
         }
     }
@@ -42,7 +43,9 @@ let Header = (props) => {
                         <HeaderItem title="군지원" />
                     </Link>
                     <HeaderItem title="커뮤니티" />
-                    <HeaderItem title="마이페이지" />
+                    <Link to="/MyPage">
+                        <HeaderItem title="마이페이지" />
+                    </Link>
                 </ul>
                 <div>
                     <Button variant="contained" className='btnLogin' style={{ margin: "5px",backgroundColor:"#183C8C"}}>

--- a/WEB(FE)/mogoon/src/components/MyPage/MyPage.js
+++ b/WEB(FE)/mogoon/src/components/MyPage/MyPage.js
@@ -1,0 +1,81 @@
+// import React, { useState } from 'react';
+import React, { useEffect, useState, useCallback } from "react";
+import SpecialtyItem from "../Specialty/SpecialtyItem.js";
+import { json, Link } from 'react-router-dom';
+import TextField from '@mui/material/TextField';
+import axios from 'axios';
+import Alert from '@mui/material/Alert';
+// redux
+import { useDispatch } from "react-redux";
+import { clearUser, loginUser } from "../../reducer/userSlice.js";
+import { useSelector } from "react-redux";
+
+// css
+import "../../css/MyPage.css"
+
+const MyPage = () => {
+    const [item, setItem] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    const token = localStorage.getItem('IdToken');
+
+    if (!token) {
+        return (
+            <div className="info-area">앗, 여긴 로그인이 필요해요!</div>
+        );
+    }
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                setLoading(true);
+                await axios.get('http://127.0.0.1:5000/api/user/info', {
+                    headers: {
+                        'Authorization': `Bearer ${token}`,
+                    },
+                }).then((response) => {
+                    return response.data;
+                }).then((data) => {
+                    setLoading(false);
+                    if (data.success)
+                        setItem(data.data);
+                    else
+                        setError(data.err_msg);
+                });    
+            } catch (error) {
+                console.log(error);
+            }
+        };
+
+        fetchData();
+    },[]);
+
+    if (loading)
+        return <div className="info-area">now Loading..</div>
+
+    if (!item) {
+        return <div>데이터가 없어요! 개발자에게 문의해주세요😨</div>
+    }
+
+    console.log(item);
+    return (
+        <div className="main-content">
+            <h2>안녕하세요, {item.name}님!😎</h2>
+            <h3>내가 찜해둔 특기</h3>
+            <div>
+                {item.favorite_speciality.map((data) => {
+                    console.log(item.favorite_speciality);
+                    return <SpecialtyItem key={data.speciality_name} code={data.speciality_code} name={data.speciality_name} class={data.class}
+                    desc={data.desc} military_kind={data.military_kind} tags={data.tags}
+                    imageSrc={data.imageSrc} kind={data.kind} like={data.like} />
+                })}
+            </div>
+            <h3>내 지원 정보</h3>
+            <h3>내 질문</h3>
+        </div>
+
+    );
+};
+
+export default React.memo(MyPage);

--- a/WEB(FE)/mogoon/src/css/MyPage.css
+++ b/WEB(FE)/mogoon/src/css/MyPage.css
@@ -1,0 +1,7 @@
+.main-content {
+    margin: 0 100px;
+}
+
+.info-area {
+    text-align: center;
+}


### PR DESCRIPTION
1. 아이디 토큰도 로컬 스토리지에 저장하도록 해서, 유저 정보 요청할 때 아이디토큰을 Authorization 헤더에 넣게 함
2. 로그아웃할 때 아이디토큰도 삭제하도록 함.
3. 마이페이지 레이아웃 잡기
4. 마이페이지 헤더와 연결
5. 마이페이지 내가 찜한 특기 리스트 불러오도록 API 연동