### PR TITLE
FEAT : 지원 정보 수정 모달창 기본 레이아웃 추가

### DIFF
--- a/WEB(FE)/mogoon/src/components/MyPage/MyEnInfoItem.js
+++ b/WEB(FE)/mogoon/src/components/MyPage/MyEnInfoItem.js
@@ -1,51 +1,45 @@
 import React, { useState } from 'react';
-import Checkbox from '@mui/material/Checkbox';
-import BookmarkIcon from '@mui/icons-material/Bookmark';
-import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
-import Badge from '@mui/material/Badge';
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { Modal } from '@mui/material';
 
 // css
+import "../../css/MyPage/Common.css";
 import "../../css/MyPage/MyEnInfoItem.css";
+import "../../css/MyPage/MyEnInfoEdit.css";
 
-let MyEnInfoItem = (props) => {
+const MyEnInfoItem = (props) => {
+
+    const [open, setOpen] = useState(false);
+
+    const handleModal = (e) => {
+        setOpen(!open);
+    };
 
     return (
-        <div className='en-info-container'>
-            <div className='en-info-header'>
-                <h4>{props.title}</h4>
-                <div className='en-info-edit'>수정</div>
+        <div>
+            <div className='en-info-container shadow-box'>
+                <div className='en-info-header'>
+                    <h4>{props.title}</h4>
+                    <div className='en-info-edit' onClick={handleModal}>수정</div>
+                </div>
+                <div className='en-info-content'>
+                    computer-engineering
+                </div>
             </div>
-            <div className='en-info-content'>
-                computer-engineering
-            </div>
+            <Modal
+                open={open}
+                onClose={handleModal}
+                aria-labelledby="modal-modal-title"
+                aria-describedby="modal-modal-description"
+            >
+                <div className='shadow-box en-info-edit-container'>
+                    <h4>{props.title}</h4>
+                    <button className='button' id='cancel-button' onClick={handleModal}>취소</button>
+                    <button className='button' id='save-button'>저장</button>
+                    
+                </div>
+            </Modal>
         </div>
-    );
-};
-
-let SpTypeItem = (props) => {
-    const type = props.type;
-
-    let typeColor = "";
-    if (type == "육군") {
-        typeColor = "green";
-    } else if (type == "해군") {
-        typeColor = "#000080";
-    } else if (type == "공군") {
-        typeColor = "#5d5d5d";
-    } else {
-        typeColor = "red";
-    }
-
-    return (
-        <div style={{ color: typeColor }}>{type}</div>
-    );
-};
-
-let SpTagItem = (props) => {
-    return (
-        //type 기본값을 이용해서 tag별로 css 적용
-        <div>#{props.tag}</div>
     );
 };
 

--- a/WEB(FE)/mogoon/src/components/MyPage/MyQuestionItem.js
+++ b/WEB(FE)/mogoon/src/components/MyPage/MyQuestionItem.js
@@ -6,12 +6,13 @@ import Badge from '@mui/material/Badge';
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 
 // css
+import "../../css/MyPage/Common.css"
 import "../../css/MyPage/MyQuestionItem.css";
 
 let MyQuestionItem = (props) => {
 
     return (
-        <div className='my-question-item-container'>
+        <div className='my-question-item-container shadow-box'>
             question1
         </div>
     );

--- a/WEB(FE)/mogoon/src/css/MyPage/Common.css
+++ b/WEB(FE)/mogoon/src/css/MyPage/Common.css
@@ -1,0 +1,38 @@
+.shadow-box {
+    border-radius: 10px;
+    background-color: white;
+    box-shadow: 0px 0.5px 7px #999999;
+}
+
+.button {
+    position: absolute;
+    border: none;
+    width: 80px;
+    height: 40px;
+    font-size: 14px;
+    border-radius: 7px;
+    box-shadow: 0px 2px 5px gray;
+    background-color: #183C8C;
+    color: white;
+    bottom: 40px;
+    cursor: pointer;
+}
+
+.button:hover {
+    background-color: #0c2761;
+}
+
+#save-button {
+    right: 50px;
+    width: 120px;
+}
+
+#cancel-button {
+    left: 50px; 
+    width: 120px;
+    background-color: #b2b2b2;
+}
+
+#cancel-button:hover {
+    background-color: #8b8b8b;
+}

--- a/WEB(FE)/mogoon/src/css/MyPage/MyEnInfoEdit.css
+++ b/WEB(FE)/mogoon/src/css/MyPage/MyEnInfoEdit.css
@@ -1,0 +1,7 @@
+.en-info-edit-container {
+    width: 300px;
+    height: 550px;
+    margin: auto;
+    margin-top: 50px;
+    padding: 40px;
+}

--- a/WEB(FE)/mogoon/src/css/MyPage/MyEnInfoItem.css
+++ b/WEB(FE)/mogoon/src/css/MyPage/MyEnInfoItem.css
@@ -5,9 +5,6 @@
     padding-top: 10px;
     padding-bottom: 16px;
     width: 220px;
-    border-radius: 10px;
-    background-color: white;
-    box-shadow: 0px 0.5px 7px #999999;
 }
 
 .en-info-header {
@@ -25,6 +22,11 @@ h4 {
     color: grey;
     font-size: 16px;
     margin-right: 4px;
+}
+
+.en-info-edit:hover {
+    text-decoration: underline;
+    cursor: pointer;
 }
 
 .en-info-content {

--- a/WEB(FE)/mogoon/src/css/MyPage/MyQuestionItem.css
+++ b/WEB(FE)/mogoon/src/css/MyPage/MyQuestionItem.css
@@ -1,7 +1,4 @@
 .my-question-item-container {
     padding: 10px 20px;
     margin: 10px;
-    border-radius: 10px;
-    background-color: white;
-    box-shadow: 0px 0.5px 7px #999999;
 }


### PR DESCRIPTION
1. 지원정보 수정 모달창 기본 레이아웃을 추가했습니다.
2. 공통으로 사용되는 셰도우 효과 박스와 버튼 디자인을 common css 파일로 빼서 관리하도록 리펙토링하였습니다.
이렇게하면 프로젝트 내 UI 디자인의 통일성을 유지하기 쉽고 코드 유지보수에
용이할 것으로 기대됩니다.